### PR TITLE
Fix methods naming

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -4,7 +4,7 @@ object Config {
     const val minSdk = 21
 
     const val major = 0
-    const val minor = 3
+    const val minor = 4
     const val patch = 0
     const val versionName = "$major.$minor.$patch"
 

--- a/data/src/main/java/ch/srg/dataProvider/integrationlayer/data/remote/MediaAggregations.kt
+++ b/data/src/main/java/ch/srg/dataProvider/integrationlayer/data/remote/MediaAggregations.kt
@@ -1,6 +1,7 @@
 package ch.srg.dataProvider.integrationlayer.data.remote
 
-import java.util.*
+import com.squareup.moshi.JsonClass
+import java.util.Date
 
 /**
  * Copyright (c) SRG SSR. All rights reserved.
@@ -12,17 +13,34 @@ sealed interface Bucket {
     val count: Int
 }
 
+@JsonClass(generateAdapter = true)
 data class MediaTypeBucket(val mediaType: MediaType, override val count: Int) : Bucket
+
+@JsonClass(generateAdapter = true)
 data class SubtitlesAvailableBucket(val subtitlesAvailable: Boolean, override val count: Int) : Bucket
 
+@JsonClass(generateAdapter = true)
 data class DownloadAvailableBucket(val downloadAvailable: Boolean, override val count: Int) : Bucket
+
+@JsonClass(generateAdapter = true)
 data class PlayableAbroadBucket(val playableAbroad: Boolean, override val count: Int) : Bucket
+
+@JsonClass(generateAdapter = true)
 data class QualityBucket(val quality: Quality, override val count: Int) : Bucket
+
+@JsonClass(generateAdapter = true)
 data class TopicBucket(val urn: String, val title: String, override val count: Int) : Bucket
+
+@JsonClass(generateAdapter = true)
 data class ShowBucket(val urn: String, val title: String, override val count: Int) : Bucket
+
+@JsonClass(generateAdapter = true)
 data class DurationInMinutesBucket(val duration: Long, override val count: Int) : Bucket
+
+@JsonClass(generateAdapter = true)
 data class DateBucket(val date: Date, override val count: Int) : Bucket
 
+@JsonClass(generateAdapter = true)
 data class MediaAggregations(
     val mediaTypeList: List<MediaTypeBucket>? = null,
     val subtitlesAvailableList: List<SubtitlesAvailableBucket>? = null,

--- a/dataprovider-paging/src/main/java/ch/srgssr/dataprovider/paging/DataProviderPaging.kt
+++ b/dataprovider-paging/src/main/java/ch/srgssr/dataprovider/paging/DataProviderPaging.kt
@@ -256,10 +256,10 @@ class DataProviderPaging @Inject constructor(
         )
     }
 
-    fun getTvAlphabeticalShows(bu: Bu, radioChannelId: String, pageSize: Int = DefaultPageSize): Flow<PagingData<Show>> {
+    fun getRadioAlphabeticalShowsByChannelId(bu: Bu, radioChannelId: String, pageSize: Int = DefaultPageSize): Flow<PagingData<Show>> {
         return createNextUrlPagingData(
             pageSize = pageSize,
-            initialCall = { ilService.getRadioAlphabeticalRadioShowsByChannelId(bu = bu, channelId = radioChannelId, pageSize = it.toIlPaging()) },
+            initialCall = { ilService.getRadioAlphabeticalShowsByChannelId(bu = bu, channelId = radioChannelId, pageSize = it.toIlPaging()) },
             nextCall = { ilService.getShowListNextUrl(it) }
         )
     }

--- a/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/request/IlService.kt
+++ b/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/request/IlService.kt
@@ -264,7 +264,7 @@ interface IlService {
     ): SongListResult
 
     @GET("2.0/{bu}/showList/radio/alphabeticalByChannel/{channelId}")
-    suspend fun getRadioAlphabeticalRadioShowsByChannelId(
+    suspend fun getRadioAlphabeticalShowsByChannelId(
         @Path("bu") bu: Bu,
         @Path("channelId") channelId: String,
         @Query("pageSize") pageSize: IlPaging?


### PR DESCRIPTION
- Fix search media, json parsing will not throw error.
- Rename endpoint methods `getRadioAlphabeticalRadioShowsByChannelId` to `getRadioAlphabeticalShowsByChannelId`