### PR TITLE
Fix image url to string

### DIFF
--- a/data/src/main/java/ch/srg/dataProvider/integrationlayer/data/ImageUrl.kt
+++ b/data/src/main/java/ch/srg/dataProvider/integrationlayer/data/ImageUrl.kt
@@ -35,4 +35,9 @@ data class ImageUrl(
     fun decorated(decorator: ImageUrlDecorator, widthPixels: Int): String {
         return decorator.decorate(rawUrl, widthPixels)
     }
+
+    @Deprecated("Using toString is not recommended in this case.", replaceWith = ReplaceWith("rawUrl"))
+    override fun toString(): String {
+        return rawUrl
+    }
 }

--- a/data/src/main/java/ch/srg/dataProvider/integrationlayer/data/ImageUrl.kt
+++ b/data/src/main/java/ch/srg/dataProvider/integrationlayer/data/ImageUrl.kt
@@ -18,11 +18,11 @@ import java.io.Serializable
 @kotlinx.serialization.Serializable(with = ImageUrlSerializer::class)
 data class ImageUrl(
     /**
-     * Only for internal use!
+     * Only for internal use! Please use a Decorator!
      *
      * @return the undecorated url
      */
-    internal val rawUrl: String
+    val rawUrl: String
 ) : Serializable {
 
     /**

--- a/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/utils/UserAgentUtils.kt
+++ b/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/utils/UserAgentUtils.kt
@@ -11,16 +11,17 @@ import android.os.Build
  * License information is available from the LICENSE file.
  */
 object UserAgentUtils {
+    private const val UNKNOWN_VERSION = "?"
 
     fun createUserAgent(application: Context): String {
         var version: String
         var verCode: Int
         try {
             val pInfo = application.packageManager.getPackageInfo(application.packageName, 0)
-            version = pInfo.versionName
+            version = pInfo.versionName ?: UNKNOWN_VERSION
             verCode = pInfo.versionCode
         } catch (ignored: PackageManager.NameNotFoundException) {
-            version = "?"
+            version = UNKNOWN_VERSION
             verCode = 0
         }
         return application.packageName + " " + version + "/" + verCode + " (" + Build.MODEL + ")"


### PR DESCRIPTION
## Goal of the PR

The goal of the PR is to make ImageUrl.rawUrl visible again. It may be usefull for integrators that use Room or other string based data storage.

The rawUrl is was never really hidden has an integrator can create an `ImageUrlDecorator` that return the rawUrl.

The decision is to revert previous modifications.