### PR TITLE
Remove implementation of SRGImageMetadata for Program, as imageUrl is nullable.

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -5,7 +5,7 @@ object Config {
 
     const val major = 0
     const val minor = 8
-    const val patch = 2
+    const val patch = 3
     const val versionName = "$major.$minor.$patch"
 
     const val maven_group = "ch.srg.data.provider"

--- a/data/src/main/java/ch/srg/dataProvider/integrationlayer/data/remote/Program.kt
+++ b/data/src/main/java/ch/srg/dataProvider/integrationlayer/data/remote/Program.kt
@@ -21,10 +21,10 @@ data class Program(
     val endTime: Date,
     override val lead: String? = null,
     override val description: String? = null,
-    override val imageUrl: ImageUrl,
-    override val imageFocalPoint: FocalPoint? = null,
-    override val imageTitle: String? = null,
-    override val imageCopyright: String? = null,
+    val imageUrl: ImageUrl? = null,
+    val imageFocalPoint: FocalPoint? = null,
+    val imageTitle: String? = null,
+    val imageCopyright: String? = null,
     val url: String? = null,
     val show: Show? = null,
     val mediaUrn: String? = null,
@@ -54,7 +54,7 @@ data class Program(
     val rebroadcastDescription: String? = null,
     val channelTitle: String? = null,
     val channelUrn: String? = null
-) : SRGImageMetadata, SRGMetadata {
+) : SRGMetadata {
 
     fun isDateInProgramTime(date: Date): Boolean {
         return date.after(startTime) && date.before(endTime)


### PR DESCRIPTION
# Motivation

`Program.imageUrl` can be null, as defined in the swagger:
<img width="336" alt="Capture d’écran 2024-04-05 à 11 56 48" src="https://github.com/SRGSSR/srgdataprovider-android/assets/12703133/6f2a2830-ca4b-425f-9208-5b5447922d02">

If no imageUrl is set, Program items can't be parsed.

It occurs in RTS TV Guide [2024-04-05 for RTS](https://il.srgssr.ch/integrationlayer/2.0/rts/programGuide/tv/byDate/2024-04-06?reduced=false&vector=APPPLAY). An item has no imageUrl. 


 # Solution approach

Remove implementation of `SRGImageMetadata` for `Program`, as `imageUrl` is nullable. 

`SRGImageMetadata.imageUrl` shouldn't be nullable as image url for other il objects is non null.

