### PR TITLE
Add the `JOURNALISTIC` blocking reason

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -5,7 +5,7 @@ object Config {
 
     const val major = 0
     const val minor = 9
-    const val patch = 1
+    const val patch = 2
     const val versionName = "$major.$minor.$patch"
 
     const val maven_group = "ch.srg.data.provider"

--- a/data/src/main/java/ch/srg/dataProvider/integrationlayer/data/remote/SRGTypes.kt
+++ b/data/src/main/java/ch/srg/dataProvider/integrationlayer/data/remote/SRGTypes.kt
@@ -39,7 +39,7 @@ enum class YouthProtectionColor {
 
 @Serializable(with = BlockReasonSerializer::class)
 enum class BlockReason {
-    GEOBLOCK, LEGAL, COMMERCIAL, AGERATING18, AGERATING12, STARTDATE, ENDDATE, UNKNOWN;
+    GEOBLOCK, LEGAL, COMMERCIAL, AGERATING18, AGERATING12, STARTDATE, ENDDATE, JOURNALISTIC, UNKNOWN;
 
     companion object {
         fun parseValue(value: String): BlockReason {


### PR DESCRIPTION
This PR adds the `JOURNALISTIC` blocking reason.

## Changes made

- Add a new `JOURNALISTIC` value to the existing `BlockReason` enum.
- Bump data provider version to 0.9.2.