### PR TITLE
Update Gradle configuration and GitHub Action workflow

### DIFF
--- a/.github/workflows/code_quality.yaml
+++ b/.github/workflows/code_quality.yaml
@@ -1,75 +1,58 @@
 name: Code quality
+
 on:
   merge_group:
   pull_request:
-    types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
   android-lint:
-    if: github.event.pull_request.draft == false
+    name: Android Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
-      - uses: reviewdog/action-setup@v1
-      - name: Run android linter
-        uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
+      - name: Run Android Lint
+        run: ./gradlew lint
+      - uses: github/codeql-action/upload-sarif@v3
+        if: success() || failure()
         with:
-          arguments: lint
-      - name: review linter
-        uses: dvdandroid/action-android-lint@master
-        with:
-          github_token: ${{ secrets.RTS_DEVOPS_GITHUB_TOKEN }}
-          lint_xml_file: ./build/reports/android-lint.xml
-          reporter: github-pr-review
-      - name: check linter
-        uses: dvdandroid/action-android-lint@master
-        with:
-          github_token: ${{ secrets.RTS_DEVOPS_GITHUB_TOKEN }}
-          lint_xml_file: ./build/reports/android-lint.xml
-          reporter: github-pr-check
+          sarif_file: build/reports/android-lint/
+          category: android-lint
 
   detekt:
-    if: github.event.pull_request.draft == false
+    name: Detekt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
-      - uses: reviewdog/action-setup@v1
-      - name: review detekt
-        uses: alaegin/Detekt-Action@v1.22.0
+      - uses: gradle/actions/setup-gradle@v3
+      - name: Run Detekt
+        run: ./gradlew detekt
+      - uses: github/codeql-action/upload-sarif@v3
+        if: success() || failure()
         with:
-          github_token: ${{ secrets.RTS_DEVOPS_GITHUB_TOKEN }}
-          detekt_config: config/detekt.yml
-          reviewdog_reporter: github-pr-review
-          detekt_excludes: "**/build/**,**/.idea/**,**/buildSrc/**,**/androidTest/**,**/test/**,**/resources/**"
-      - name: check detekt
-        uses: alaegin/Detekt-Action@v1.22.0
-        with:
-          github_token: ${{ secrets.RTS_DEVOPS_GITHUB_TOKEN }}
-          detekt_config: config/detekt.yml
-          reviewdog_reporter: github-pr-check
-          detekt_excludes: "**/build/**,**/.idea/**,**/buildSrc/**,**/androidTest/**,**/test/**,**/resources/**"
+          sarif_file: build/reports/detekt.sarif
+          category: detekt
 
-  android-unit-test:
-    if: github.event.pull_request.draft == false
+  unit-test:
+    name: Unit Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
-      - name: Run android local unit test
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: testDebug
+      - uses: gradle/actions/setup-gradle@v3
+      - name: Run Unit Tests
+        run: ./gradlew testDebug

--- a/README.md
+++ b/README.md
@@ -9,4 +9,3 @@ The library provides:
 * Requests with Retrofit to get the usual metadata associated with SRG SSR productions.
 * Gson serialization and deserialization.
 * A flat object model to easily access the data relevant to front-end users.
-* Dagger2 modules to easy integration.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 import io.gitlab.arturbosch.detekt.Detekt
+import io.gitlab.arturbosch.detekt.report.ReportMergeTask
 
 plugins {
     alias(libs.plugins.android.application) apply false
@@ -7,6 +8,12 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     // https://github.com/detekt/detekt
     alias(libs.plugins.detekt)
+}
+
+apply(plugin = "android-reporting")
+
+val detektReportMerge by tasks.registering(ReportMergeTask::class) {
+    output.set(rootProject.layout.buildDirectory.file("reports/detekt.sarif"))
 }
 
 allprojects {
@@ -28,14 +35,18 @@ allprojects {
             xml.required.set(false)
             html.required.set(true)
             txt.required.set(false)
-            sarif.required.set(false)
+            sarif.required.set(true)
             md.required.set(false)
         }
+        finalizedBy(detektReportMerge)
     }
 
     dependencies {
-        //noinspection UseTomlInstead
-        detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.22.0")
+        detektPlugins(libs.detekt.formatting)
+    }
+
+    detektReportMerge {
+        input.from(tasks.withType<Detekt>().map { it.sarifReportFile })
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.Detekt
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.kotlin.kapt) apply false
     alias(libs.plugins.kotlin.android) apply false
     // https://github.com/detekt/detekt
     alias(libs.plugins.detekt)

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.kotlin.kapt)
     `maven-publish`
 }
 

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -40,6 +40,8 @@ android {
     lint {
         // https://developer.android.com/reference/tools/gradle-api/4.1/com/android/build/api/dsl/LintOptions
         abortOnError = false
+        sarifReport = true
+        sarifOutput = rootProject.layout.buildDirectory.file("reports/android-lint/${project.name}.sarif").get().asFile
     }
     publishing {
         singleVariant("release") {
@@ -51,7 +53,6 @@ android {
 
 dependencies {
     api(libs.kotlinx.serialization.json)
-    detektPlugins(libs.detekt.formatting)
 
     testImplementation(libs.robolectric)
     testImplementation(libs.junit)

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -50,15 +50,12 @@ android {
 }
 
 dependencies {
-    implementation(libs.core.ktx)
     api(libs.kotlinx.serialization.json)
     detektPlugins(libs.detekt.formatting)
 
     testImplementation(libs.robolectric)
     testImplementation(libs.junit)
-    testImplementation(libs.junit.ktx)
-    androidTestImplementation(libs.ext.junit)
-    androidTestImplementation(libs.espresso.core)
+    testImplementation(libs.ext.junit)
 }
 
 publishing {

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -24,6 +24,12 @@ android {
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }
+
+    buildFeatures {
+        resValues = false
+        shaders = false
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8

--- a/dataprovider-paging/build.gradle.kts
+++ b/dataprovider-paging/build.gradle.kts
@@ -49,14 +49,8 @@ android {
 }
 
 dependencies {
-    api(project(mapOf("path" to ":dataprovider-retrofit")))
-    implementation(libs.core.ktx)
-    implementation(libs.lifecycle.viewmodel.ktx)
-    api(libs.paging.runtime.ktx)
-
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.ext.junit)
-    androidTestImplementation(libs.espresso.core)
+    api(project(":dataprovider-retrofit"))
+    api(libs.paging.common)
 }
 
 publishing {

--- a/dataprovider-paging/build.gradle.kts
+++ b/dataprovider-paging/build.gradle.kts
@@ -23,6 +23,12 @@ android {
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }
+
+    buildFeatures {
+        resValues = false
+        shaders = false
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8

--- a/dataprovider-paging/build.gradle.kts
+++ b/dataprovider-paging/build.gradle.kts
@@ -39,6 +39,8 @@ android {
     lint {
         // https://developer.android.com/reference/tools/gradle-api/4.1/com/android/build/api/dsl/LintOptions
         abortOnError = false
+        sarifReport = true
+        sarifOutput = rootProject.layout.buildDirectory.file("reports/android-lint/${project.name}.sarif").get().asFile
     }
     publishing {
         singleVariant("release") {

--- a/dataprovider-retrofit/build.gradle.kts
+++ b/dataprovider-retrofit/build.gradle.kts
@@ -23,6 +23,12 @@ android {
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }
+
+    buildFeatures {
+        resValues = false
+        shaders = false
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8

--- a/dataprovider-retrofit/build.gradle.kts
+++ b/dataprovider-retrofit/build.gradle.kts
@@ -39,6 +39,8 @@ android {
     lint {
         // https://developer.android.com/reference/tools/gradle-api/4.1/com/android/build/api/dsl/LintOptions
         abortOnError = false
+        sarifReport = true
+        sarifOutput = rootProject.layout.buildDirectory.file("reports/android-lint/${project.name}.sarif").get().asFile
     }
     publishing {
         singleVariant("release") {

--- a/dataprovider-retrofit/build.gradle.kts
+++ b/dataprovider-retrofit/build.gradle.kts
@@ -49,21 +49,15 @@ android {
 }
 
 dependencies {
-    api(project(mapOf("path" to ":data")))
-    implementation(libs.core.ktx)
-    api(libs.lifecycle.livedata.ktx)
-
-    //retrofit implementation
+    api(project(":data"))
     api(libs.retrofit)
+    compileOnly(libs.androidx.annotation)
     implementation(libs.retrofit2.kotlinx.serialization.converter)
-    //noinspection GradleDependency
     implementation(libs.logging.interceptor)
 
-    testImplementation(libs.junit.ktx)
     testImplementation(libs.junit)
     testRuntimeOnly(libs.robolectric)
-    androidTestImplementation(libs.ext.junit)
-    androidTestImplementation(libs.espresso.core)
+    testImplementation(libs.ext.junit)
 }
 
 publishing {

--- a/dataproviderdemo/build.gradle.kts
+++ b/dataproviderdemo/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.kapt)
 }
 
 android {

--- a/dataproviderdemo/build.gradle.kts
+++ b/dataproviderdemo/build.gradle.kts
@@ -56,14 +56,9 @@ android {
 }
 
 dependencies {
-    implementation(project(mapOf("path" to ":dataprovider-retrofit")))
-    implementation(project(mapOf("path" to ":dataprovider-paging")))
-    implementation(libs.core.ktx)
+    implementation(project(":dataprovider-retrofit"))
     implementation(libs.appcompat)
     implementation(libs.material)
     implementation(libs.constraintlayout)
-
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.ext.junit)
-    androidTestImplementation(libs.espresso.core)
+    implementation(libs.lifecycle.viewmodel)
 }

--- a/dataproviderdemo/build.gradle.kts
+++ b/dataproviderdemo/build.gradle.kts
@@ -49,8 +49,8 @@ android {
         abortOnError = true
         checkAllWarnings = true
         checkDependencies = false
-        xmlReport = true // Enable for Danger Android Lint
-        xmlOutput = file("${project.rootDir}/build/reports/android-lint.xml")
+        sarifReport = true
+        sarifOutput = rootProject.layout.buildDirectory.file("reports/android-lint/${project.name}.sarif").get().asFile
         disable.add("LogConditional")
     }
 }

--- a/dataproviderdemo/build.gradle.kts
+++ b/dataproviderdemo/build.gradle.kts
@@ -31,6 +31,11 @@ android {
         }
     }
 
+    buildFeatures {
+        resValues = false
+        shaders = false
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,5 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,42 +1,36 @@
 [versions]
 androidGradlePlugin = "8.1.1"
 androidx-junit = "1.1.5"
+androidx-annotation = "1.3.0"
 appcompat = "1.6.1"
 constraintlayout = "2.1.4"
-core-ktx = "1.10.1"
 detekt = "1.22.0"
-espresso-core = "3.5.1"
 junit = "4.13.2"
 kotlinPlugin = "1.9.10"
 kotlinxSerializationJson = "1.6.0"
-lifecycle-viewmodel-ktx = "2.6.1"
+lifecycle-viewmodel = "2.6.1"
 logging-interceptor = "4.9.1"
 material = "1.9.0"
-paging-runtime-ktx = "3.2.0"
+paging-common = "3.2.0"
 retrofit = "2.9.0"
 retrofit2KotlinxSerializationConverter = "1.0.0"
 robolectric = "4.11.1"
-junitKtx = "1.1.5"
 
 [libraries]
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
-core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso-core" }
 ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-junit" }
 junit = { module = "junit:junit", version.ref = "junit" }
-lifecycle-livedata-ktx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycle-viewmodel-ktx" }
-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle-viewmodel-ktx" }
+lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "lifecycle-viewmodel" }
 logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "logging-interceptor" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
-paging-runtime-ktx = { module = "androidx.paging:paging-runtime-ktx", version.ref = "paging-runtime-ktx" }
+paging-common = { module = "androidx.paging:paging-common", version.ref = "paging-common" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
-detekt-cli = { group = "io.gitlab.arturbosch.detekt", name = "detekt-cli", version.ref = "detekt" }
 detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 retrofit2-kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofit2KotlinxSerializationConverter" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
-junit-ktx = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "junitKtx" }
+androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,6 @@ androidx-junit = "1.1.5"
 appcompat = "1.6.1"
 constraintlayout = "2.1.4"
 core-ktx = "1.10.1"
-dagger = "2.47"
 detekt = "1.22.0"
 espresso-core = "3.5.1"
 junit = "4.13.2"
@@ -23,8 +22,6 @@ junitKtx = "1.1.5"
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
 core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
-dagger = { module = "com.google.dagger:dagger", version.ref = "dagger" }
-dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
 espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso-core" }
 ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-junit" }
 junit = { module = "junit:junit", version.ref = "junit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,6 @@ junit-ktx = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "ju
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlinPlugin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinPlugin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinPlugin" }
 


### PR DESCRIPTION
## Changes made

- Update the `code_quality.yml` workflow to use the latest actions versions.
- Make Android Lint and Detekt generate SARIF files to be used by the `code_quality.yml` workflow.
- Let the `code_quality.yml` workflow run for any PR, even in draft.
- Remove unused dependencies from each modules.
- Remove unused KAPT Gradle plugin.
- Disable unused features in Android Gradle Plugin (`BuildConfig`, res value and shaders generation).

## Notes

- No project dependencies have been updated in this PR.
- I didn't update the data provider version, as this doesn't need a dedicated release.
- If these changes should be merged, the branch protection rule needs to be updated to use the new validation names (`Android Lint`, `Detekt`, and `Unit Test`).