### PR TITLE
Add missing fields to `Chapter` and update `TimeInterval`

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -4,8 +4,8 @@ object Config {
     const val minSdk = 21
 
     const val major = 0
-    const val minor = 9
-    const val patch = 2
+    const val minor = 10
+    const val patch = 0
     const val versionName = "$major.$minor.$patch"
 
     const val maven_group = "ch.srg.data.provider"

--- a/data/src/main/java/ch/srg/dataProvider/integrationlayer/data/remote/Chapter.kt
+++ b/data/src/main/java/ch/srg/dataProvider/integrationlayer/data/remote/Chapter.kt
@@ -1,4 +1,5 @@
 @file:UseSerializers(DateSerializer::class)
+
 package ch.srg.dataProvider.integrationlayer.data.remote
 
 import ch.srg.dataProvider.integrationlayer.data.ImageUrl
@@ -40,6 +41,8 @@ data class Chapter(
     override val socialCountList: List<SocialCountEntry>? = null,
     override val displayable: Boolean = false,
     override val fullLengthUrn: String? = null,
+    val fullLengthMarkIn: Long? = null,
+    val fullLengthMarkOut: Long? = null,
     override val eventData: String? = null,
     override val subtitleList: List<Subtitle>? = null,
     @SerialName("analyticsData")

--- a/data/src/main/java/ch/srg/dataProvider/integrationlayer/data/remote/TimeInterval.kt
+++ b/data/src/main/java/ch/srg/dataProvider/integrationlayer/data/remote/TimeInterval.kt
@@ -8,7 +8,11 @@ import kotlinx.serialization.Serializable
  * License information is available from the LICENSE file.
  */
 @Serializable
-data class TimeInterval(val type: Type, val markIn: Long, val markOut: Long) {
+data class TimeInterval(
+    val type: Type?,
+    val markIn: Long?,
+    val markOut: Long?,
+) {
 
     enum class Type {
         OPENING_CREDITS, CLOSING_CREDITS


### PR DESCRIPTION
In the scope of https://github.com/SRGSSR/pillarbox-android/issues/460, we'd like to replace Pillarbox models of the integration layer objects with those from data provider.

To do so, we need the following changes proposed in this PR:
- Add `fullLengthMarkIn` and `fullLengthMarkOut` to `Chapter`.
<img width="218" alt="Screenshot 2024-05-17 at 16 22 31" src="https://github.com/SRGSSR/srgdataprovider-android/assets/1009664/ba08edff-2f0e-44fe-b70f-6973a600c785">

- Make `type`, `markIn`, and `markOut` nullable in `TimeInterval`.
<img width="302" alt="Screenshot 2024-05-17 at 16 22 52" src="https://github.com/SRGSSR/srgdataprovider-android/assets/1009664/d6861f36-78e5-4839-b93d-5dd6654dc83a">

I've bump the library version to 0.10.0 since the changes in `TimeInterval` could break if someone is using that class. Let me know if I should use an other version.