### PR TITLE
Dont add vector if already present in url.

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -5,7 +5,7 @@ object Config {
 
     const val major = 0
     const val minor = 10
-    const val patch = 0
+    const val patch = 1
     const val versionName = "$major.$minor.$patch"
 
     const val maven_group = "ch.srg.data.provider"

--- a/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/utils/VectorInterceptor.kt
+++ b/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/utils/VectorInterceptor.kt
@@ -13,14 +13,19 @@ import okhttp3.Response
 class VectorInterceptor(private val vector: String) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
-        val original = chain.request()
-        val originalHttpUrl = original.url
+        val originalRequest = chain.request()
+        val originalHttpUrl = originalRequest.url
+
+        if (originalHttpUrl.queryParameter("vector") != null) {
+            return chain.proceed(originalRequest)
+        }
+
         val url = originalHttpUrl.newBuilder()
             .addQueryParameter("vector", vector)
             .build()
 
         // Request customization: add request headers
-        val requestBuilder = original.newBuilder()
+        val requestBuilder = originalRequest.newBuilder()
             .url(url)
         val request = requestBuilder.build()
         return chain.proceed(request)


### PR DESCRIPTION
This PR prevent vector to be added twice if already present in the URL.

Fix issue #42 