### PR TITLE
Update demo app to display request response

### DIFF
--- a/dataproviderdemo/src/main/java/ch/srgssr/dataprovider/demo/MainActivity.kt
+++ b/dataproviderdemo/src/main/java/ch/srgssr/dataprovider/demo/MainActivity.kt
@@ -1,7 +1,9 @@
 package ch.srgssr.dataprovider.demo
 
 import android.os.Bundle
-import android.util.Log
+import android.view.View
+import android.widget.ProgressBar
+import android.widget.TextView
 import androidx.activity.ComponentActivity
 import androidx.activity.enableEdgeToEdge
 import androidx.lifecycle.Lifecycle
@@ -12,12 +14,15 @@ import ch.srg.dataProvider.integrationlayer.dependencies.modules.OkHttpModule
 import ch.srg.dataProvider.integrationlayer.request.IlHost
 import ch.srg.dataProvider.integrationlayer.request.IlService
 import ch.srg.dataProvider.integrationlayer.request.parameters.Bu
-import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 
 class MainActivity : ComponentActivity(R.layout.activity_main) {
+
+    private lateinit var loadingProgressBar: ProgressBar
+    private lateinit var messageTextView: TextView
 
     private lateinit var okHttp: OkHttpClient
     private lateinit var ilService: IlService
@@ -27,18 +32,37 @@ class MainActivity : ComponentActivity(R.layout.activity_main) {
 
         super.onCreate(savedInstanceState)
 
+        loadingProgressBar = findViewById(R.id.loading_pb)
+        messageTextView = findViewById(R.id.message_tv)
+
         okHttp = OkHttpModule.createOkHttpClient(this)
         ilService = IlServiceModule.createIlService(okHttp, ilHost = IlHost.PROD)
 
-        val flowData = flow {
+        getTvLatestEpisodes()
+    }
+
+    private fun getTvLatestEpisodes() {
+        val tvLatestEpisodesFlow = flow {
             emit(ilService.getTvLatestEpisodes(Bu.RTS))
         }
 
         lifecycleScope.launch {
             lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
-                flowData.collectLatest {
-                    Log.d("Coucou", "${it.list}")
-                }
+                tvLatestEpisodesFlow
+                    .catch { exception ->
+                        loadingProgressBar.visibility = View.GONE
+                        messageTextView.text = exception.message
+                        messageTextView.visibility = View.VISIBLE
+                    }
+                    .collect { tvLatestEpisodes ->
+                        val episodesNames = tvLatestEpisodes.list.joinToString(separator = "\n") {
+                            "${it.show?.title} - ${it.title}"
+                        }
+
+                        loadingProgressBar.visibility = View.GONE
+                        messageTextView.text = episodesNames
+                        messageTextView.visibility = View.VISIBLE
+                    }
             }
         }
     }

--- a/dataproviderdemo/src/main/res/layout/activity_main.xml
+++ b/dataproviderdemo/src/main/res/layout/activity_main.xml
@@ -3,11 +3,22 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     tools:context=".MainActivity">
 
     <TextView
+        android:id="@+id/message_tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:visibility="gone"
+        tools:text="Hello World!"
+        tools:visibility="visible" />
+
+    <ProgressBar
+        android:id="@+id/loading_pb"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:text="Hello World!" />
+        android:indeterminate="true" />
 </FrameLayout>


### PR DESCRIPTION
As discussed in https://github.com/SRGSSR/srgdataprovider-android/pull/46#discussion_r1738281007, I've updated the demo app to get rid of the `Log` `Coucou` and replaced it with a simple UI:

| Loading | Success | Error |
|-----|-----|------|
| ![Screenshot_20240830_132703](https://github.com/user-attachments/assets/a82d4d94-15c6-4fa4-b648-0713ec8555ec) | ![Screenshot_20240830_132716](https://github.com/user-attachments/assets/e192332f-e602-4813-8b75-0ca7b7b36c54) | ![Screenshot_20240830_132854](https://github.com/user-attachments/assets/a5183f08-02c0-475d-b7e1-e298c74c34a5) |