### PR TITLE
Add param `forceSAM=true` when targeting sam endpoint

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -5,7 +5,7 @@ object Config {
 
     const val major = 0
     const val minor = 11
-    const val patch = "0.test-force-sam"
+    const val patch = 1
     const val versionName = "$major.$minor.$patch"
 
     const val maven_group = "ch.srg.data.provider"

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -4,8 +4,8 @@ object Config {
     const val minSdk = 21
 
     const val major = 0
-    const val minor = 10
-    const val patch = 1
+    const val minor = 11
+    const val patch = "0.test-force-sam"
     const val versionName = "$major.$minor.$patch"
 
     const val maven_group = "ch.srg.data.provider"

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -4,7 +4,7 @@ object Config {
     const val minSdk = 21
 
     const val major = 0
-    const val minor = 11
+    const val minor = 10
     const val patch = 1
     const val versionName = "$major.$minor.$patch"
 

--- a/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/dependencies/modules/OkHttpModule.kt
+++ b/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/dependencies/modules/OkHttpModule.kt
@@ -2,6 +2,7 @@ package ch.srg.dataProvider.integrationlayer.dependencies.modules
 
 import android.content.Context
 import android.content.res.Configuration
+import ch.srg.dataProvider.integrationlayer.utils.HostInterceptor
 import ch.srg.dataProvider.integrationlayer.utils.UserAgentInterceptor
 import ch.srg.dataProvider.integrationlayer.utils.UserAgentUtils
 import ch.srg.dataProvider.integrationlayer.utils.VectorInterceptor
@@ -31,6 +32,7 @@ object OkHttpModule {
         logging.setLevel(HttpLoggingInterceptor.Level.HEADERS)
         builder.addInterceptor(logging)
         builder.addInterceptor(UserAgentInterceptor(UserAgentUtils.createUserAgent(context)))
+        builder.addInterceptor(HostInterceptor())
         builder.addInterceptor(VectorInterceptor(vector))
         builder.readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         builder.connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)

--- a/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/utils/HostInterceptor.kt
+++ b/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/utils/HostInterceptor.kt
@@ -1,0 +1,29 @@
+package ch.srg.dataProvider.integrationlayer.utils
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * Adds a query parameter "forceSAM=true" to each SAM HTTP request.
+ * See [IlHost] for more details.
+ */
+class HostInterceptor : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request()
+        val originalHttpUrl = originalRequest.url
+
+        if (originalHttpUrl.queryParameter("forceSAM") != null || !originalHttpUrl.pathSegments.contains("sam")) {
+            return chain.proceed(originalRequest)
+        }
+
+        val url = originalHttpUrl.newBuilder()
+            .addQueryParameter("forceSAM", "true")
+            .build()
+
+        // Request customization: add request headers
+        val requestBuilder = originalRequest.newBuilder().url(url)
+        val request = requestBuilder.build()
+        return chain.proceed(request)
+    }
+}

--- a/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/utils/HostInterceptor.kt
+++ b/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/utils/HostInterceptor.kt
@@ -13,17 +13,21 @@ class HostInterceptor : Interceptor {
         val originalRequest = chain.request()
         val originalHttpUrl = originalRequest.url
 
-        if (originalHttpUrl.queryParameter("forceSAM") != null || !originalHttpUrl.pathSegments.contains("sam")) {
+        if (originalHttpUrl.queryParameter(FORCE_SAM) != null || !originalHttpUrl.pathSegments.contains("sam")) {
             return chain.proceed(originalRequest)
         }
 
         val url = originalHttpUrl.newBuilder()
-            .addQueryParameter("forceSAM", "true")
+            .addQueryParameter(FORCE_SAM, "true")
             .build()
 
         // Request customization: add request headers
         val requestBuilder = originalRequest.newBuilder().url(url)
         val request = requestBuilder.build()
         return chain.proceed(request)
+    }
+
+    companion object {
+        private const val FORCE_SAM = "forceSAM"
     }
 }


### PR DESCRIPTION
# Description

All sam call need to have the param `forceSAM=true` to ensure call are retrieved from SAM and not proxied through IL. 

# Changes made:

- Add `HostInterceptor` to add param `forceSAM=true` to all calls made to sam end points (prod, stage, test).