### PR TITLE
Fix Maven publication

### DIFF
--- a/.github/workflows/code_quality.yaml
+++ b/.github/workflows/code_quality.yaml
@@ -59,3 +59,17 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
       - name: Run Unit Tests
         run: ./gradlew testDebug
+
+  maven-local-publication:
+    name: Publish to Maven Local
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Publish to Maven Local
+        run: ./gradlew publishToMavenLocal

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ allprojects {
     }
 
     tasks.withType<Detekt>().configureEach {
-        jvmTarget = "17"
+        jvmTarget = "11"
         reports {
             xml.required.set(false)
             html.required.set(true)

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -30,11 +30,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "11"
     }
     lint {
         // https://developer.android.com/reference/tools/gradle-api/4.1/com/android/build/api/dsl/LintOptions

--- a/dataprovider-paging/build.gradle.kts
+++ b/dataprovider-paging/build.gradle.kts
@@ -29,11 +29,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "11"
     }
     lint {
         // https://developer.android.com/reference/tools/gradle-api/4.1/com/android/build/api/dsl/LintOptions

--- a/dataprovider-retrofit/build.gradle.kts
+++ b/dataprovider-retrofit/build.gradle.kts
@@ -29,11 +29,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "11"
     }
     lint {
         // https://developer.android.com/reference/tools/gradle-api/4.1/com/android/build/api/dsl/LintOptions

--- a/dataproviderdemo/build.gradle.kts
+++ b/dataproviderdemo/build.gradle.kts
@@ -37,11 +37,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "11"
     }
 
     lint {


### PR DESCRIPTION
There was an issue with Maven publication when using Java 17.
I wasn't able to figure out the exact cause, but using Java 11 seems to work fine, so I've updated the project to use that version.
I've also updated the `code_quality.yml` workflow to add a step to publish to Maven local, so we can always ensure that publication works.

The error that was happening can be seen in the build log of the first commit: https://github.com/SRGSSR/srgdataprovider-android/actions/runs/12274751507/job/34248321537?pr=64