### PR TITLE
Update to Gradle 8.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ## About
 
-The SRG Data Provider library provides a simple way to retrieve metadata for all SRG SSRG business units in a common format.
+The SRG Data Provider library provides a simple way to retrieve metadata for all SRG SSR business units in a common format.
 
 The library provides:
 
-* Requests with Retrofit to get the usual metadata associated with SRG SSR productions.
-* Gson serialization and deserialization.
+* Requests with [Retrofit](https://github.com/square/retrofit) to get the usual metadata associated with SRG SSR productions.
+* [KotlinX Serialization](https://github.com/Kotlin/kotlinx.serialization) serialization and deserialization.
 * A flat object model to easily access the data relevant to front-end users.

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,16 +4,29 @@
 # any settings specified in this file.
 # For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
+
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+# https://docs.gradle.org/current/userguide/performance.html#increase_the_heap_size
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+# https://docs.gradle.org/current/userguide/performance.html#parallel_execution
+org.gradle.parallel=true
+
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK
-# https://developer.android.com/topic/libraries/support-library/androidx-rn
+# https://developer.android.com/jetpack/androidx#using_androidx_libraries_in_your_project
 android.useAndroidX=true
+
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+# Gradle's Build Cache
+# https://docs.gradle.org/current/userguide/performance.html#enable_the_build_cache
+org.gradle.caching=true
+
+# Let Detekt use Gradle's Worker API
+# https://detekt.dev/docs/gettingstarted/gradle/#options-for-detekt-gradle-properties
+detekt.use.worker.api=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum


### PR DESCRIPTION
This PR updates Gradle to 8.12. The release notes are available below:
- [8.11](https://docs.gradle.org/8.11/release-notes.html).
- [8.11.1](https://docs.gradle.org/8.11.1/release-notes.html).
- [8.12](https://docs.gradle.org/8.12/release-notes.html).

Additional changes:
- Update readme to remove mention of Gson and fix a typo.
- Enable Gradle's parallel mode and caching.