### PR TITLE
Add the `VPNORPROXYDETECTED` blocking reason

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -4,8 +4,8 @@ object Config {
     const val minSdk = 21
 
     private const val major = 0
-    private const val minor = 13
-    private const val patch = 2
+    private const val minor = 14
+    private const val patch = 0
     const val versionName = "$major.$minor.$patch"
 
     const val mavenGroup = "ch.srg.data.provider"

--- a/data/src/main/java/ch/srg/dataProvider/integrationlayer/data/remote/SRGTypes.kt
+++ b/data/src/main/java/ch/srg/dataProvider/integrationlayer/data/remote/SRGTypes.kt
@@ -39,7 +39,7 @@ enum class YouthProtectionColor {
 
 @Serializable(with = BlockReasonSerializer::class)
 enum class BlockReason {
-    GEOBLOCK, LEGAL, COMMERCIAL, AGERATING18, AGERATING12, STARTDATE, ENDDATE, JOURNALISTIC, UNKNOWN;
+    GEOBLOCK, LEGAL, COMMERCIAL, AGERATING18, AGERATING12, STARTDATE, ENDDATE, JOURNALISTIC, VPNORPROXYDETECTED, UNKNOWN;
 
     companion object {
         fun parseValue(value: String): BlockReason {


### PR DESCRIPTION
This PR adds the `VPNORPROXYDETECTED` blocking reason.

## Changes made

- Add the `VPNORPROXYDETECTED` blocking reason.
- Bump the library version to 0.14.0.