### PR TITLE
Update IlService to add new scheduled live stream and remove suppressed endpoint

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -5,7 +5,7 @@ object Config {
 
     private const val major = 0
     private const val minor = 15
-    private const val patch = "0.debug"
+    private const val patch = 0
     const val versionName = "$major.$minor.$patch"
 
     const val mavenGroup = "ch.srg.data.provider"

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -4,8 +4,8 @@ object Config {
     const val minSdk = 21
 
     private const val major = 0
-    private const val minor = 14
-    private const val patch = 0
+    private const val minor = 15
+    private const val patch = "0.debug"
     const val versionName = "$major.$minor.$patch"
 
     const val mavenGroup = "ch.srg.data.provider"

--- a/data/src/main/java/ch/srg/dataProvider/integrationlayer/data/remote/SRGTypes.kt
+++ b/data/src/main/java/ch/srg/dataProvider/integrationlayer/data/remote/SRGTypes.kt
@@ -33,6 +33,10 @@ enum class LiveCenterType {
     EPISODE, SCHEDULED_LIVESTREAM
 }
 
+enum class EventType {
+    NEWS, SPORT
+}
+
 enum class YouthProtectionColor {
     RED, YELLOW
 }

--- a/dataprovider-paging/src/main/java/ch/srgssr/dataprovider/paging/DataProviderPaging.kt
+++ b/dataprovider-paging/src/main/java/ch/srgssr/dataprovider/paging/DataProviderPaging.kt
@@ -88,14 +88,6 @@ class DataProviderPaging(
         }).flow
     }
 
-    fun getMediaRecommendedByUrn(urn: String, pageSize: Int = DEFAULT_PAGE_SIZE): Flow<PagingData<Media>> {
-        return createNextUrlPagingData(
-            pageSize = pageSize,
-            initialCall = { ilService.getMediaRecommendedByUrn(urn, it.toIlPaging()) },
-            nextCall = { ilService.getMediaListNextUrl(it) }
-        )
-    }
-
     fun getLatestMediaByTopicUrn(topicUrn: String, pageSize: Int = DEFAULT_PAGE_SIZE): Flow<PagingData<Media>> {
         return createNextUrlPagingData(
             pageSize = pageSize,

--- a/dataprovider-paging/src/main/java/ch/srgssr/dataprovider/paging/DataProviderPaging.kt
+++ b/dataprovider-paging/src/main/java/ch/srgssr/dataprovider/paging/DataProviderPaging.kt
@@ -234,22 +234,12 @@ class DataProviderPaging(
         )
     }
 
-    fun getAllAlphabeticalShows(bu: Bu, transmission: Transmission, radioChannelId: String? = null): Flow<PagingData<Show>> {
-        return createNextUrlPagingData(
-            pageSize = DEFAULT_PAGE_SIZE,
-            initialCall = {
-                ilService.getAllAlphabeticalShows(
-                    bu = bu, transmission = IlTransmission(transmission),
-                    radioChannelId = radioChannelId
-                )
-            }, nextCall = { ilService.getShowListNextUrl(it) }
-        )
-    }
-
-    fun getTvAlphabeticalShows(bu: Bu, pageSize: Int = DEFAULT_PAGE_SIZE): Flow<PagingData<Show>> {
+    fun getAlphabeticalShows(bu: Bu, transmission: Transmission, pageSize: Int = DEFAULT_PAGE_SIZE): Flow<PagingData<Show>> {
         return createNextUrlPagingData(
             pageSize = pageSize,
-            initialCall = { ilService.getTvAlphabeticalShows(bu = bu, pageSize = it.toIlPaging()) },
+            initialCall = {
+                ilService.getAlphabeticalShows(bu = bu, transmission = IlTransmission(transmission), pageSize = it.toIlPaging())
+            },
             nextCall = { ilService.getShowListNextUrl(it) }
         )
     }

--- a/dataprovider-paging/src/main/java/ch/srgssr/dataprovider/paging/DataProviderPaging.kt
+++ b/dataprovider-paging/src/main/java/ch/srgssr/dataprovider/paging/DataProviderPaging.kt
@@ -4,6 +4,7 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import ch.srg.dataProvider.integrationlayer.data.remote.Episode
+import ch.srg.dataProvider.integrationlayer.data.remote.EventType
 import ch.srg.dataProvider.integrationlayer.data.remote.ListResult
 import ch.srg.dataProvider.integrationlayer.data.remote.LiveCenterType
 import ch.srg.dataProvider.integrationlayer.data.remote.Media
@@ -20,6 +21,7 @@ import ch.srg.dataProvider.integrationlayer.request.SearchProvider
 import ch.srg.dataProvider.integrationlayer.request.parameters.Bu
 import ch.srg.dataProvider.integrationlayer.request.parameters.IlDate
 import ch.srg.dataProvider.integrationlayer.request.parameters.IlDateTime
+import ch.srg.dataProvider.integrationlayer.request.parameters.IlEventType
 import ch.srg.dataProvider.integrationlayer.request.parameters.IlMediaType
 import ch.srg.dataProvider.integrationlayer.request.parameters.IlPaging.Unlimited.toIlPaging
 import ch.srg.dataProvider.integrationlayer.request.parameters.IlTransmission
@@ -187,10 +189,17 @@ class DataProviderPaging(
         )
     }
 
-    fun getScheduledLiveStreamVideos(bu: Bu, signLanguageOnly: Boolean = false, pageSize: Int = DEFAULT_PAGE_SIZE): Flow<PagingData<Media>> {
+    fun getScheduledLiveStreamVideos(
+        bu: Bu,
+        signLanguageOnly: Boolean = false,
+        eventType: EventType,
+        pageSize: Int = DEFAULT_PAGE_SIZE
+    ): Flow<PagingData<Media>> {
         return createNextUrlPagingData(
             pageSize = pageSize,
-            initialCall = { ilService.getScheduledLiveStreamVideos(bu, signLanguageOnly, it.toIlPaging()) },
+            initialCall = {
+                ilService.getScheduledLiveStreamVideos(bu, signLanguageOnly, IlEventType(eventType), it.toIlPaging())
+            },
             nextCall = { ilService.getMediaListNextUrl(it) }
         )
     }

--- a/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/request/IlService.kt
+++ b/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/request/IlService.kt
@@ -22,6 +22,7 @@ import ch.srg.dataProvider.integrationlayer.data.remote.TopicListResult
 import ch.srg.dataProvider.integrationlayer.request.parameters.Bu
 import ch.srg.dataProvider.integrationlayer.request.parameters.IlDate
 import ch.srg.dataProvider.integrationlayer.request.parameters.IlDateTime
+import ch.srg.dataProvider.integrationlayer.request.parameters.IlEventType
 import ch.srg.dataProvider.integrationlayer.request.parameters.IlMediaType
 import ch.srg.dataProvider.integrationlayer.request.parameters.IlPaging
 import ch.srg.dataProvider.integrationlayer.request.parameters.IlTransmission
@@ -307,6 +308,7 @@ interface IlService {
     suspend fun getScheduledLiveStreamVideos(
         @Path("bu") bu: Bu,
         @Query("signLanguageOnly") signLanguageOnly: Boolean = false,
+        @Query("eventType") eventType: IlEventType? = null,
         @Query("pageSize") pageSize: IlPaging.Size? = null,
     ): MediaListResult
 

--- a/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/request/IlService.kt
+++ b/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/request/IlService.kt
@@ -202,9 +202,10 @@ interface IlService {
         @Query("reduced") reduced: Boolean = false
     ): ProgramGuide
 
-    @GET("2.0/{bu}/showList/tv/alphabetical")
-    suspend fun getTvAlphabeticalShows(
+    @GET("2.0/{bu}/showList/{transmission}/alphabetical")
+    suspend fun getAlphabeticalShows(
         @Path("bu") bu: Bu,
+        @Path("transmission") transmission: IlTransmission,
         @Query("pageSize") pageSize: IlPaging?
     ): ShowListResult
 
@@ -362,13 +363,6 @@ interface IlService {
         @Query("livestreamId") liveStreamId: String?,
         @Query("pageSize") pageSize: IlPaging.Size? = null,
     ): ProgramCompositionListResult
-
-    @GET("2.0/{bu}/showList/{transmission}/alphabetical/all")
-    suspend fun getAllAlphabeticalShows(
-        @Path("bu") bu: Bu,
-        @Path("transmission") transmission: IlTransmission,
-        @Query("channelId") radioChannelId: String? = null
-    ): ShowListResult
 
     @GET("2.0/{bu}/showList/mostClickedSearchResults")
     suspend fun getTop10MostClickedSearchShow(

--- a/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/request/IlService.kt
+++ b/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/request/IlService.kt
@@ -75,12 +75,6 @@ interface IlService {
         @Query("pageSize") pageSize: IlPaging.Size? = null
     ): MediaListResult
 
-    @GET("2.0/mediaList/recommended/byUrn/{urn}")
-    suspend fun getMediaRecommendedByUrn(
-        @Path("urn") urn: String,
-        @Query("pageSize") pageSize: IlPaging.Size? = null
-    ): MediaListResult
-
     /**
      * @param showUrns         List of show urns, max element = 15
      * @param onlyEpisodes     Return only episodes.

--- a/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/request/parameters/IlEventType.kt
+++ b/dataprovider-retrofit/src/main/java/ch/srg/dataProvider/integrationlayer/request/parameters/IlEventType.kt
@@ -1,0 +1,10 @@
+package ch.srg.dataProvider.integrationlayer.request.parameters
+
+import ch.srg.dataProvider.integrationlayer.data.remote.EventType
+
+/**
+ * Copyright (c) SRG SSR. All rights reserved.
+ * <p>
+ * License information is available from the LICENSE file.
+ */
+class IlEventType(eventType: EventType) : IlParam(eventType.toString().lowercase())


### PR DESCRIPTION
## Changes Made

### Updated call
- Add `EventType` property to `@GET("2.0/{bu}/mediaList/video/scheduledLivestreams")`
- `@GET("2.0/{bu}/showList/{transmission}/alphabetical")` can now handle both transmission type. (tv and radio)

### Removed call no more supported by IL
- `@GET("2.0/{bu}/showList/{transmission}/alphabetical/all")` 
- `@GET("2.0/mediaList/recommended/byUrn/{urn}")`

+ make changes in `DataProviderPaging`