### PR TITLE
Make `EventType` optional for scheduled live streams

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -5,7 +5,7 @@ object Config {
 
     private const val major = 0
     private const val minor = 15
-    private const val patch = 0
+    private const val patch = 1
     const val versionName = "$major.$minor.$patch"
 
     const val mavenGroup = "ch.srg.data.provider"

--- a/dataprovider-paging/src/main/java/ch/srgssr/dataprovider/paging/DataProviderPaging.kt
+++ b/dataprovider-paging/src/main/java/ch/srgssr/dataprovider/paging/DataProviderPaging.kt
@@ -184,13 +184,18 @@ class DataProviderPaging(
     fun getScheduledLiveStreamVideos(
         bu: Bu,
         signLanguageOnly: Boolean = false,
-        eventType: EventType,
+        eventType: EventType? = null,
         pageSize: Int = DEFAULT_PAGE_SIZE
     ): Flow<PagingData<Media>> {
         return createNextUrlPagingData(
             pageSize = pageSize,
             initialCall = {
-                ilService.getScheduledLiveStreamVideos(bu, signLanguageOnly, IlEventType(eventType), it.toIlPaging())
+                ilService.getScheduledLiveStreamVideos(
+                    bu = bu,
+                    signLanguageOnly = signLanguageOnly,
+                    eventType = eventType?.let(::IlEventType),
+                    pageSize = it.toIlPaging(),
+                )
             },
             nextCall = { ilService.getMediaListNextUrl(it) }
         )


### PR DESCRIPTION
The newly added `EventType` argument of `DataProviderPaging#getScheduledLiveStreamVideos()` is mandatory. But it is optional in `IlService#getScheduledLiveStreamVideos()`. This makes it difficult to request unfiltered events.

This PR changes that by allowing `null` event type to `DataProviderPaging#getScheduledLiveStreamVideos()`.