### PR TITLE
Fix the `Android Lint` step in `code_quality.yml`

### DIFF
--- a/.github/workflows/code_quality.yaml
+++ b/.github/workflows/code_quality.yaml
@@ -11,6 +11,13 @@ jobs:
   android-lint:
     name: Android Lint
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - module: 'data'
+          - module: 'dataprovider-paging'
+          - module: 'dataprovider-retrofit'
+          - module: 'dataproviderdemo'
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -20,12 +27,12 @@ jobs:
           distribution: 'temurin'
       - uses: gradle/actions/setup-gradle@v4
       - name: Run Android Lint
-        run: ./gradlew lint
+        run: ./gradlew ${{ matrix.module }}:lintDebug
       - uses: github/codeql-action/upload-sarif@v3
         if: ${{ !cancelled() }}
         with:
-          sarif_file: build/reports/android-lint/
-          category: android-lint
+          sarif_file: build/reports/android-lint/${{ matrix.module }}.sarif
+          category: android-lint-${{ matrix.module }}
 
   detekt:
     name: Detekt


### PR DESCRIPTION
This PR fixes the `Android Lint` step of the `code_quality.yml` workflow.
It is no longer possible to upload multiple SARIF files for a single category. So now we use one category per Gradle module.
This change is based on what was done in [pillarbox-android](https://github.com/SRGSSR/pillarbox-android/pull/1118).